### PR TITLE
Accept PKCS#8 private keys as well

### DIFF
--- a/lib/Vyatta/OpenVPN/Config.pm
+++ b/lib/Vyatta/OpenVPN/Config.pm
@@ -675,7 +675,7 @@ sub get_command {
     
     return (undef, 'Must specify "tls key-file"')
       if (!defined($self->{_tls_key}));
-    $hdrs = checkHeader("-----BEGIN RSA PRIVATE KEY-----", $self->{_tls_key});
+    $hdrs = checkHeader("-----BEGIN (?:RSA )?PRIVATE KEY-----", $self->{_tls_key});
     return (undef, "Specified key-file \"$self->{_tls_key}\" is not valid")
       if ($hdrs != 0); 
     $cmd .= " --key $self->{_tls_key}";


### PR DESCRIPTION
OpenVPN can work with both PKCS#1 (BEGIN RSA PRIVATE KEY) and
PKCS#8 (BEGIN PRIVATE KEY) private keys for TLS authentication.

This change makes the configuration checker accept both as well.
