### PR TITLE
Multiple commits relating to Bug #7 and Bug #313

### DIFF
--- a/lib/Vyatta/OpenVPN/Config.pm
+++ b/lib/Vyatta/OpenVPN/Config.pm
@@ -182,7 +182,7 @@ sub setup {
     $self->{_qos_out} = $config->returnValue('traffic-policy out');
     $self->{_qos_in} = $config->returnValue('traffic-policy in');
     $self->{_redirect} = $config->returnValue('redirect');
-    if ($config->exists('persistent-interface')) {
+    if ($config->exists('persistent-tunnel')) {
         $self->{_persistent_intf} = 1;
     }
     my @options = $config->returnValues('openvpn-option');
@@ -300,7 +300,7 @@ sub setupOrig {
     $self->{_qos_out} = $config->returnOrigValue('traffic-policy out');
     $self->{_qos_in} = $config->returnOrigValue('traffic-policy in');
     $self->{_redirect} = $config->returnOrigValue('redirect');
-    if ($config->existsOrig('persistent-interface')) {
+    if ($config->existsOrig('persistent-tunnel')) {
         $self->{_persistent_intf} = 1;
     }
     my @options = $config->returnOrigValues('openvpn-option');

--- a/lib/Vyatta/OpenVPN/Config.pm
+++ b/lib/Vyatta/OpenVPN/Config.pm
@@ -894,11 +894,7 @@ sub get_command {
     }
     
     if ($self->{_persistent_intf}) {
-        if ($self->{_mode} eq 'server') {
-            return (undef, 'Cannot set "persistent-tunnel" in server mode');
-        } else {
-            $cmd .= " --persist-tun ";
-        }
+        $cmd .= " --persist-tun ";
     }
 
     # extra options

--- a/scripts/vyatta-reset-client-ovpn.pl
+++ b/scripts/vyatta-reset-client-ovpn.pl
@@ -48,7 +48,7 @@ sub reset_client {
     print $socket "kill $cn\n";
     chomp($line = <$socket>);
     if ($line =~ /SUCCESS/) {
-        print "Client with command-name '$cn' has been reset.\n";
+        print "Client with Common-Name '$cn' has been reset.\n";
         return 0;
     } elsif ($line =~ /ERROR/) {
         return 1;

--- a/scripts/vyatta-reset-client-ovpn.pl
+++ b/scripts/vyatta-reset-client-ovpn.pl
@@ -34,37 +34,34 @@ my $line;
 
 ##Main
 unless (-e "/tmp/openvpn-mgmt-intf") {
-  print "This command is only supported by OpenVPN in server mode\n";
-  exit 1;
-} 
+    print "This command is only supported by OpenVPN in server mode\n";
+    exit 1;
+}
 
-my $socket = IO::Socket::UNIX->new(
-  Type => SOCK_STREAM,
-  Peer => $socket_path,
-)
-  or die("Cannot connect to management interface\n");
+my $socket = IO::Socket::UNIX->new(Type => SOCK_STREAM, Peer => $socket_path,)
+    or die("Cannot connect to management interface\n");
 
-chomp( $line = <$socket> );
+chomp($line = <$socket>);
 
 sub reset_client {
-  my $cn = shift;
-  print $socket "kill $cn\n";
-  chomp( $line = <$socket> );
-  if ($line =~ /SUCCESS/) {
-    print "Client with command-name '$cn' has been reset.\n";
-    return 0;
-  } 
-  elsif ($line =~ /ERROR/) { 
-    return 1;
-  }
+    my $cn = shift;
+    print $socket "kill $cn\n";
+    chomp($line = <$socket>);
+    if ($line =~ /SUCCESS/) {
+        print "Client with command-name '$cn' has been reset.\n";
+        return 0;
+    } elsif ($line =~ /ERROR/) {
+        return 1;
+    }
 }
 
 if ($cn) {
-  if (reset_client($cn)) {
-    print "Invalid Common-Name\n";
-    exit 1; 
-  }
+    if (reset_client($cn)) {
+        print "Invalid Common-Name\n";
+        exit 1;
+    }
 }
+
 shutdown($socket, 2)
-  or die ("Error closing the socket\n");
+    or die("Error closing the socket\n");
 exit 0;

--- a/scripts/vyatta-restart-ovpn.pl
+++ b/scripts/vyatta-restart-ovpn.pl
@@ -16,7 +16,7 @@
 # Portions created by Vyatta are Copyright (C) 2007 Vyatta, Inc.
 # All Rights Reserved.
 #
-# Author: Deepti Kulkarni 
+# Author: Deepti Kulkarni
 # Date: Oct 2010
 # Description: Script to restart openvpn process
 #
@@ -28,40 +28,39 @@ use strict;
 use IO::Prompt;
 use Getopt::Long;
 use Vyatta::Interface;
- 
+
 my $vtun;
 my $pid;
 my $cmd = 'kill -USR1 ';
 
 sub is_valid_intf {
- my $name = shift;
- my $intf = new Vyatta::Interface($name);
- return unless $intf;
+    my $name = shift;
+    my $intf = new Vyatta::Interface($name);
+    return unless $intf;
 
- return $intf->exists();
+    return $intf->exists();
 }
 
 ## Main
 
 GetOptions("vtun=s" => \$vtun);
 if ($vtun) {
-  die "Invalid interface [$vtun]\n"
-   unless is_valid_intf($vtun);
+    die "Invalid interface [$vtun]\n"
+        unless is_valid_intf($vtun);
 }
+
 print "This will reset and re-establish all tunnel connections on this interface.\n";
 
-if ((defined($ENV{VYATTA_PROCESS_CLIENT}) && $ENV{VYATTA_PROCESS_CLIENT} eq 'gui2_rest') || 
-    prompt("Are you sure you want to continue? (y/n)", -y1d=>"y")){
-  $pid = `cat /var/run/openvpn-$vtun.pid`;
-   if ($pid) {
-      $cmd .= "$pid";
-      system($cmd);
-      print "Tunnel connections for interface $vtun have been reset.\n";
-   }
-   else {
-    print "No tunnel connection on interface $vtun.\n";
-   }
-  }
-else{
-  print "Reset cancelled\n";
+if ((defined($ENV{VYATTA_PROCESS_CLIENT}) && $ENV{VYATTA_PROCESS_CLIENT} eq 'gui2_rest')
+  || prompt("Are you sure you want to continue? (y/n)", -y1d=>"y")) {
+    $pid = `cat /var/run/openvpn-$vtun.pid`;
+    if ($pid) {
+        $cmd .= "$pid";
+        system($cmd);
+        print "Tunnel connections for interface $vtun have been reset.\n";
+    } else {
+        print "No tunnel connection on interface $vtun.\n";
+    }
+} else {
+    print "Reset cancelled\n";
 }

--- a/scripts/vyatta-restart-ovpn.pl
+++ b/scripts/vyatta-restart-ovpn.pl
@@ -28,10 +28,12 @@ use strict;
 use IO::Prompt;
 use Getopt::Long;
 use Vyatta::Interface;
+use Vyatta::Config;
 
 my $vtun;
 my $pid;
 my $cmd = 'kill -USR1 ';
+my $reset_persistent = 0;
 
 sub is_valid_intf {
     my $name = shift;
@@ -39,6 +41,15 @@ sub is_valid_intf {
     return unless $intf;
 
     return $intf->exists();
+}
+
+sub is_persistent {
+    my $intf = shift;
+    my $config = new Vyatta::Config;
+
+    $config->setLevel("interfaces openvpn $intf");
+    
+    return $config->existsOrig('persistent-tunnel');
 }
 
 ## Main
@@ -51,13 +62,21 @@ if ($vtun) {
 
 print "This will reset and re-establish all tunnel connections on this interface.\n";
 
-if ((defined($ENV{VYATTA_PROCESS_CLIENT}) && $ENV{VYATTA_PROCESS_CLIENT} eq 'gui2_rest')
-  || prompt("Are you sure you want to continue? (y/n)", -y1d=>"y")) {
+if ((defined($ENV{VYATTA_PROCESS_CLIENT}) && $ENV{VYATTA_PROCESS_CLIENT} eq 'gui2_rest') || prompt("Are you sure you want to continue? (Y/n)", -y1d=>"y")) {
+    if (is_persistent($vtun) && prompt("This is a persistent tunnel, do you want to reset the interface? (Y/n)", -y1d=>"y")) {
+        # Send SIGHUP rather than SIGUSR1 to force the interface to reset
+        $reset_persistent = 1;
+        $cmd = 'kill -HUP ';
+    }
     $pid = `cat /var/run/openvpn-$vtun.pid`;
     if ($pid) {
         $cmd .= "$pid";
         system($cmd);
-        print "Tunnel connections for interface $vtun have been reset.\n";
+        if ($reset_persistent) {
+            print "Both the tunnel connections and interface for $vtun have been reset.\n";
+        }else {
+            print "Tunnel connections for interface $vtun have been reset.\n";
+        }
     } else {
         print "No tunnel connection on interface $vtun.\n";
     }

--- a/scripts/vyatta-show-ovpn.pl
+++ b/scripts/vyatta-show-ovpn.pl
@@ -6,247 +6,243 @@ use lib "/opt/vyatta/share/perl5/";
 use Vyatta::Config;
 
 #valid modes
-my %mode_hash = ( 
-  'server'	=> \&output_server_status,
-  'client'	=> \&output_client_status,
-  'site-to-site' => \&output_sitetosite_status,
+my %mode_hash = (
+    'server'	=> \&output_server_status,
+    'client'	=> \&output_client_status,
+    'site-to-site' => \&output_sitetosite_status,
 );
 
 ##main
 my $mode;
 my $client;
 
-GetOptions("mode=s" => \$mode,
-           "show=s" => \$client);
+GetOptions(
+    "mode=s" => \$mode,
+    "show=s" => \$client
+);
 
 my $STATUS_PATH = '/opt/vyatta/etc/openvpn/status';
-show_client_names($client)            if ($client);
+show_client_names($client)
+    if ($client);
 
 if (!opendir(SDIR, "$STATUS_PATH")) {
-  print STDERR "Cannot get status information\n";
-  exit 1;
+    print STDERR "Cannot get status information\n";
+    exit 1;
 }
-my @vtuns = grep { /\.status$/ } readdir(SDIR);
+my @vtuns = grep {/\.status$/} readdir(SDIR);
 closedir(SDIR);
 if ((scalar @vtuns) <= 0) {
-  print STDERR "Cannot find active OpenVPN tunnels\n";
-  exit 1;
+    print STDERR "Cannot find active OpenVPN tunnels\n";
+    exit 1;
 }
 
 sub stat2str {
-  my $stat = shift;
-  return 'N/A' if (!defined($stat));
-  if ($stat > 1000000000) {
-    $stat = sprintf('%.1fG', ($stat / 1000000000));
-  } elsif ($stat > 1000000) {
-    $stat = sprintf('%.1fM', ($stat / 1000000));
-  } elsif ($stat > 1000) {
-    $stat = sprintf('%.1fK', ($stat / 1000));
-  }
-  return $stat;
+    my $stat = shift;
+    return 'N/A' if (!defined($stat));
+    if ($stat > 1000000000) {
+        $stat = sprintf('%.1fG', ($stat / 1000000000));
+    } elsif ($stat > 1000000) {
+        $stat = sprintf('%.1fM', ($stat / 1000000));
+    } elsif ($stat > 1000) {
+        $stat = sprintf('%.1fK', ($stat / 1000));
+    }
+    return $stat;
 }
 
 sub output_server_status {
-  my $intf = shift;
-  my @lines = @_;
-  my $config = new Vyatta::Config;
-  $config->setLevel("interfaces openvpn $intf");
-  my $desc = $config->returnOrigValue("description");
-   
-  if (!($lines[0] =~ /^OpenVPN CLIENT LIST$/)) {
-    return 0;
-  }
-  print <<EOH;
+    my $intf = shift;
+    my @lines = @_;
+    my $config = new Vyatta::Config;
+    $config->setLevel("interfaces openvpn $intf");
+    my $desc = $config->returnOrigValue("description");
+
+    if (!($lines[0] =~ /^OpenVPN CLIENT LIST$/)) {
+        return 0;
+    }
+    print <<EOH;
 OpenVPN server status on $intf [$desc] 
 
 Client CN       Remote IP       Tunnel IP       TX byte RX byte Connected Since
 --------------- --------------- --------------- ------- ------- ------------------------
 EOH
 
-  my @clients = ();
-  my %routes = ();
-  my $i = 3;
-  while (!($lines[$i] =~ /^ROUTING TABLE$/)) {
-    push @clients, $lines[$i];
+    my @clients = ();
+    my %routes = ();
+    my $i = 3;
+    while (!($lines[$i] =~ /^ROUTING TABLE$/)) {
+        push @clients, $lines[$i];
+        $i++;
+    }
     $i++;
-  }
-  $i++;
-  while (!($lines[$i] =~ /^GLOBAL STATS$/)) {
-    my ($tip, $rip) = (split /,/, $lines[$i])[0,2];
-    $routes{$rip} = $tip
-	unless $tip =~ /C$|\//;		# skip server-configured and client-learned routes
-    $i++;
-  }
+    while (!($lines[$i] =~ /^GLOBAL STATS$/)) {
+        my ($tip, $rip) = (split /,/, $lines[$i])[0,2];
+        $routes{$rip} = $tip
+            unless $tip =~ /C$|\//;    # skip server-configured and client-learned routes
+        $i++;
+    }
 
-  for (@clients) {
-    my ($name, $rip_str, $recv, $sent, $since) = split /,/;
-    chomp $since;
-    my $tip_str = $routes{$rip_str}; 
-    my $rip = (split /:/, $rip_str)[0];
-    my $rbytes = stat2str($recv);
-    my $sbytes = stat2str($sent);
+    for (@clients) {
+        my ($name, $rip_str, $recv, $sent, $since) = split /,/;
+        chomp $since;
+        my $tip_str = $routes{$rip_str};
+        my $rip = (split /:/, $rip_str)[0];
+        my $rbytes = stat2str($recv);
+        my $sbytes = stat2str($sent);
 
-    printf "%-15s %-15s %-15s %7s %7s %s\n",
-           $name, $rip, $tip_str, $sbytes, $rbytes, $since;
-  }
+        printf "%-15s %-15s %-15s %7s %7s %s\n",$name, $rip, $tip_str, $sbytes, $rbytes, $since;
+    }
+    print "\n\n";
 
-  print "\n\n";
-
-  return 1;
+    return 1;
 }
 
 sub parse_status {
-  my ($intf, $mode, @lines) = @_; 
-  my @values = (); 
-  my $config = new Vyatta::Config;
-  if (!($lines[0] =~ /^OpenVPN STATISTICS$/)) {
-    return 0;
-  }
-  my $rbytes;
-  my $sbytes;
-  my $i = 2;
-  while (!($lines[$i] =~ /^Auth/)) {
-   if ($lines[$i] =~ /^[A-Z\/]+ read bytes/) {
-     my @recv = split (/,/,$lines[$i]);
-     $rbytes = $rbytes + $recv[1];
-   }
-   elsif ($lines[$i] =~ /^[A-Z\/]+ write bytes/) {
-     my @sent = split (/,/,$lines[$i]);
-     $sbytes = $sbytes + $sent[1];
-   }
-   $i++;
-  }
-   my $recv = stat2str($rbytes);
-   my $sent = stat2str($sbytes);
-   $config->setLevel("interfaces openvpn $intf");
-   my $desc = $config->returnOrigValue("description");
-   my @remote = $config->returnOrigValues("remote-host");
-   if ((scalar @remote) > 1) {
-     $remote[0] = "N/A";
-   }
-   push (@values, $desc, $remote[0]);
-   push (@values, $sent, $recv);
-   if ($mode eq "site-to-site") {
-     my $rsite = "N/A"; 
-     my $rtunnel = $config->returnOrigValue("remote-address");
-     if ($config->existsOrig("shared-secret-key-file")) {
-      $rsite = "None (PSK)";
-     }
-     push (@values, $rsite, $rtunnel); 
-   }
-   return @values;
+    my ($intf, $mode, @lines) = @_;
+    my @values = ();
+    my $config = new Vyatta::Config;
+    if (!($lines[0] =~ /^OpenVPN STATISTICS$/)) {
+        return 0;
+    }
+    my $rbytes;
+    my $sbytes;
+    my $i = 2;
+    while (!($lines[$i] =~ /^Auth/)) {
+        if ($lines[$i] =~ /^[A-Z\/]+ read bytes/) {
+            my @recv = split(/,/,$lines[$i]);
+            $rbytes = $rbytes + $recv[1];
+        }elsif ($lines[$i] =~ /^[A-Z\/]+ write bytes/) {
+            my @sent = split(/,/,$lines[$i]);
+            $sbytes = $sbytes + $sent[1];
+        }
+        $i++;
+    }
+    my $recv = stat2str($rbytes);
+    my $sent = stat2str($sbytes);
+    $config->setLevel("interfaces openvpn $intf");
+    my $desc = $config->returnOrigValue("description");
+    my @remote = $config->returnOrigValues("remote-host");
+    if ((scalar @remote) > 1) {
+        $remote[0] = "N/A";
+    }
+    push(@values, $desc, $remote[0]);
+    push(@values, $sent, $recv);
+    if ($mode eq "site-to-site") {
+        my $rsite = "N/A";
+        my $rtunnel = $config->returnOrigValue("remote-address");
+        if ($config->existsOrig("shared-secret-key-file")) {
+            $rsite = "None (PSK)";
+        }
+        push(@values, $rsite, $rtunnel);
+    }
+    return @values;
 }
 
 sub parse_common_name  {
-  my $intf = shift;
-  my @lines = @_;
-  my @clients = ();
-  my @cn;
-  my $i = 3;
-  while (!($lines[$i] =~ /^ROUTING TABLE$/)) {
-    push @clients, $lines[$i];
-    $i++;
-  }
-  for (@clients) {
-    my ($name, $rip_str, $recv, $sent, $since) = split /,/;
-    push @cn, $name;
-  }
-  print join(' ', @cn), "\n";
+    my $intf = shift;
+    my @lines = @_;
+    my @clients = ();
+    my @cn;
+    my $i = 3;
+    while (!($lines[$i] =~ /^ROUTING TABLE$/)) {
+        push @clients, $lines[$i];
+        $i++;
+    }
+    for (@clients) {
+        my ($name, $rip_str, $recv, $sent, $since) = split /,/;
+        push @cn, $name;
+    }
+    print join(' ', @cn), "\n";
 }
 
 # generate one line with all client CN's for allowed
 sub show_client_names {
-  my $mode = "server";
-  my $client = shift;
-  if (!opendir(SDIR, "$STATUS_PATH")) {
-    exit 1;
-  }
-  my @vtuns = grep { /\.status$/ } readdir(SDIR);
-  closedir(SDIR);
-  if ((scalar @vtuns) <= 0) {
-    exit 1;
-  }
-  my $config = new Vyatta::Config;
-  foreach my $vtun (@vtuns) {
-    $vtun =~ /^(.*)\.status$/;
-    my $intf = $1;
-    $config->setLevel("interfaces openvpn $intf");
-    my $modeVal = $config->returnOrigValue("mode");
-    if ($mode eq $modeVal) {
-    if (!open(VT, "$STATUS_PATH/$vtun")) {
-      next;
+    my $mode = "server";
+    my $client = shift;
+    if (!opendir(SDIR, "$STATUS_PATH")) {
+        exit 1;
     }
-    my @slines = <VT>;
-    close VT;
-    parse_common_name($intf, @slines);
+    my @vtuns = grep {/\.status$/} readdir(SDIR);
+    closedir(SDIR);
+    if ((scalar @vtuns) <= 0) {
+        exit 1;
     }
-  }
-  exit 0;
+    my $config = new Vyatta::Config;
+    foreach my $vtun (@vtuns) {
+        $vtun =~ /^(.*)\.status$/;
+        my $intf = $1;
+        $config->setLevel("interfaces openvpn $intf");
+        my $modeVal = $config->returnOrigValue("mode");
+        if ($mode eq $modeVal) {
+            if (!open(VT, "$STATUS_PATH/$vtun")) {
+                next;
+            }
+            my @slines = <VT>;
+            close VT;
+            parse_common_name($intf, @slines);
+        }
+    }
+    exit 0;
 }
 
 sub output_client_status {
-  my $intf = shift;
-  my @lines = @_;
-  my $mode = "client"; 
-  my ($desc, $remote, $sent, $recv) = parse_status($intf, $mode, @lines); 
-  print <<EOH;
+    my $intf = shift;
+    my @lines = @_;
+    my $mode = "client";
+    my ($desc, $remote, $sent, $recv) = parse_status($intf, $mode, @lines);
+    print <<EOH;
 OpenVPN client status on $intf [$desc]
 
 Server CN       Remote IP       Tunnel IP       TX byte RX byte Connected Since
 --------------- --------------- --------------- ------- ------- ------------------------
 EOH
- 
-  printf "%-15s %-15s %-15s %7s %7s %s\n",
-           "N/A", $remote, "N/A", $sent, $recv, "N/A";
-  print "\n\n";
-  return 1;
+
+    printf "%-15s %-15s %-15s %7s %7s %s\n","N/A", $remote, "N/A", $sent, $recv, "N/A";
+    print "\n\n";
+    return 1;
 }
 
-
 sub output_sitetosite_status {
-  my $intf = shift;
-  my @lines = @_;
-  my $mode = "site-to-site";
-  my ($desc, $remote, $sent, $recv, $rsite, $rtunnel) = parse_status($intf, $mode, @lines); 
-  print <<EOH;
+    my $intf = shift;
+    my @lines = @_;
+    my $mode = "site-to-site";
+    my ($desc, $remote, $sent, $recv, $rsite, $rtunnel) = parse_status($intf, $mode, @lines);
+    print <<EOH;
 OpenVPN client status on $intf [$desc] 
 
 Remote CN       Remote IP       Tunnel IP       TX byte RX byte Connected Since
 --------------- --------------- --------------- ------- ------- ------------------------
 EOH
-  printf "%-15s %-15s %-15s %7s %7s %s\n",
-           $rsite, $remote, $rtunnel, $sent, $recv, "N/A";
-  print "\n\n";
-  return 1;
+    printf "%-15s %-15s %-15s %7s %7s %s\n",$rsite, $remote, $rtunnel, $sent, $recv, "N/A";
+    print "\n\n";
+    return 1;
 }
 
 my $status_shown = 0;
 my $config = new Vyatta::Config;
 foreach my $vtun (@vtuns) {
-  $vtun =~ /^(.*)\.status$/;
-  my $intf = $1;
-  $config->setLevel("interfaces openvpn $intf");
-  my $modeVal = $config->returnOrigValue("mode"); 
-  if ($mode eq $modeVal) {
-   if (!open(VT, "$STATUS_PATH/$vtun")) {
-    print STDERR "Cannot get status for \"$intf\"\n";
-    next;
-   }
-   my @slines = <VT>;
-   close VT;
-   my $func;
-   if (defined $mode_hash{$mode}) {
-    $func = $mode_hash{$mode};
-   } 
-   if (&$func($intf, @slines)) {
-    $status_shown = 1;
-   }
-  }
- }
+    $vtun =~ /^(.*)\.status$/;
+    my $intf = $1;
+    $config->setLevel("interfaces openvpn $intf");
+    my $modeVal = $config->returnOrigValue("mode");
+    if ($mode eq $modeVal) {
+        if (!open(VT, "$STATUS_PATH/$vtun")) {
+            print STDERR "Cannot get status for \"$intf\"\n";
+            next;
+        }
+        my @slines = <VT>;
+        close VT;
+        my $func;
+        if (defined $mode_hash{$mode}) {
+            $func = $mode_hash{$mode};
+        }
+        if (&$func($intf, @slines)) {
+            $status_shown = 1;
+        }
+    }
+}
 if (!$status_shown) {
-  print STDERR "Cannot find active OpenVPN $mode connections\n";
-  exit 1;
+    print STDERR "Cannot find active OpenVPN $mode connections\n";
+    exit 1;
 }
 
 exit 0;
-

--- a/scripts/vyatta-update-ovpn.pl
+++ b/scripts/vyatta-update-ovpn.pl
@@ -14,57 +14,59 @@ $config->setup($vtun);
 $oconfig->setupOrig($vtun);
 
 if (!($config->isDifferentFrom($oconfig))) {
-  if ($config->isEmpty()) {
-    print STDERR "Empty Configuration\n";
-    exit 1;
-  } 
-  # config not changed. do nothing.
-  exit 0;
+    if ($config->isEmpty()) {
+        print STDERR "Empty Configuration\n";
+        exit 1;
+    }
+
+    # config not changed. do nothing.
+    exit 0;
 }
 
 if ($config->isEmpty()) {
-  # deleted
-  Vyatta::OpenVPN::Config::kill_daemon($vtun);
-  $oconfig->removeBridge();
-  # delete the server status file if exists
-  if (-e "$statusDir/$vtun.status") {
-  `rm -f $statusDir/$vtun.status 2> /dev/null`;  
-  } 
-  exit 0;
+
+    # deleted
+    Vyatta::OpenVPN::Config::kill_daemon($vtun);
+    $oconfig->removeBridge();
+
+    # delete the server status file if exists
+    if (-e "$statusDir/$vtun.status") {
+        `rm -f $statusDir/$vtun.status 2> /dev/null`;
+    }
+    exit 0;
 }
 
 my ($cmd, $err) = $config->get_command();
 
 if ($config->isRestartNeeded($oconfig) && defined($cmd)) {
-  Vyatta::OpenVPN::Config::kill_daemon($vtun);
-  $oconfig->removeBridge();
-  $config->setupBridge();
-  $config->configureBridge();
-  if ("$cmd" ne 'disable') { 
-     system("$cmd");
-     if ($? >> 8) {
-       $err = 'Failed to start OpenVPN tunnel';
-     }
-   if (-x $multicast_script && ! defined($err)) {
-     if (system("$multicast_script --if_type openvpn --if_name $vtun") != 0) {
-        $err = "Error during execution of $multicast_script";
-     }
-   }
-  }
+    Vyatta::OpenVPN::Config::kill_daemon($vtun);
+    $oconfig->removeBridge();
+    $config->setupBridge();
+    $config->configureBridge();
+    if ("$cmd" ne 'disable') {
+        system("$cmd");
+        if ($? >> 8) {
+            $err = 'Failed to start OpenVPN tunnel';
+        }
+        if (-x $multicast_script && !defined($err)) {
+            if (system("$multicast_script --if_type openvpn --if_name $vtun") != 0) {
+                $err = "Error during execution of $multicast_script";
+            }
+        }
+    }
 }
 my $description = $config->{_description};
-  if ("$description" ne "" && -e "/sys/class/net/$vtun/ifalias")
-    {
-      my $cmdDesc = "echo \"$description\" >> /sys/class/net/$vtun/ifalias";
-      system($cmdDesc);
-    }
+if ("$description" ne "" && -e "/sys/class/net/$vtun/ifalias"){
+    my $cmdDesc = "echo \"$description\" >> /sys/class/net/$vtun/ifalias";
+    system($cmdDesc);
+}
 
 if (defined($err)) {
-  print STDERR "OpenVPN configuration error: $err.\n";
-  # remove the openvpn interface from bridge group on commit failure.
-  $config->removeBridge(); 
-  exit 1;
+    print STDERR "OpenVPN configuration error: $err.\n";
+
+    # remove the openvpn interface from bridge group on commit failure.
+    $config->removeBridge();
+    exit 1;
 }
 
 exit 0;
-

--- a/templates-cfg/interfaces/openvpn/node.tag/persistent-tunnel/node.def
+++ b/templates-cfg/interfaces/openvpn/node.tag/persistent-tunnel/node.def
@@ -1,1 +1,1 @@
-Help: Do not close and reopen interface (TUN/TAP device) on client restarts
+help: Do not close and reopen interface (TUN/TAP device) on client restarts


### PR DESCRIPTION
vyatta-openvpn: correct a typo in server mode reset message.

Correct a typo in vyatta-reset-client-ovpn.pl for the message returned
when resetting a client in server mode.

vyatta-openvpn: correct a typo in the persistent-tunnel template

Correct a typo in the persistent-tunnel template node.def introduced
for Bug #7 and Bug #313

vyatta-openvpn: correct wrong node name usage for persistent tunnels

Correction for wrong node name usage in the code for persistent openvpn
tunnels, added for Bug #7 and Bug #313

vyatta-openvpn: persistent tunnels in server mode and allow full reset

Allow OpenVPN tunnels (vtun) that are configured for server mode
operation to be set as persistent (TUN/TAP interfaces aren't closed
and reopened on a reset).  Check if the tunnel is configured for
persistence when 'reset openvpn interface' is run from the CLI, if it
then prompt the user if an interface reset is required along with the
tunnel reset (defaults to yes).

Bug #7 http://bugzilla.vyos.net/show_bug.cgi?id=7
Bug #313 http://bugzilla.vyos.net/show_bug.cgi?id=313
