### PR TITLE
Commits for Bug #318/319 and Bug #320

### DIFF
--- a/scripts/vyatta-restart-ovpn.pl
+++ b/scripts/vyatta-restart-ovpn.pl
@@ -60,26 +60,29 @@ if ($vtun) {
         unless is_valid_intf($vtun);
 }
 
-print "This will reset and re-establish all tunnel connections on this interface.\n";
+print "\nThis will reset and re-establish all tunnel connections on this interface.\n";
 
-if ((defined($ENV{VYATTA_PROCESS_CLIENT}) && $ENV{VYATTA_PROCESS_CLIENT} eq 'gui2_rest') || prompt("Are you sure you want to continue? (Y/n)", -y1d=>"y")) {
-    if (is_persistent($vtun) && prompt("This is a persistent tunnel, do you want to reset the interface? (Y/n)", -y1d=>"y")) {
-        # Send SIGHUP rather than SIGUSR1 to force the interface to reset
-        $reset_persistent = 1;
-        $cmd = 'kill -HUP ';
+if ((defined($ENV{VYATTA_PROCESS_CLIENT}) && $ENV{VYATTA_PROCESS_CLIENT} eq 'gui2_rest') || prompt("Are you sure you want to continue? (y/n)", -y1d=>"y")) {
+    if (is_persistent($vtun)) {
+        print "\nThis interface has been configured as a persistent tunnel, so will be reused.\n";
+        if (prompt("Do you want to reset the interface as well? (y/n)", -y1d=>"y")) {
+            # Send SIGHUP rather than SIGUSR1 to force the interface to reset
+            $reset_persistent = 1;
+            $cmd = 'kill -HUP ';
+        }
     }
     $pid = `cat /var/run/openvpn-$vtun.pid`;
     if ($pid) {
         $cmd .= "$pid";
         system($cmd);
         if ($reset_persistent) {
-            print "Both the tunnel connections and interface for $vtun have been reset.\n";
+            print "\nBoth the tunnel connections and interface for $vtun have been reset.\n";
         }else {
-            print "Tunnel connections for interface $vtun have been reset.\n";
+            print "\nTunnel connections for interface $vtun have been reset.\n";
         }
     } else {
-        print "No tunnel connection on interface $vtun.\n";
+        print "\nNo tunnel connection on interface $vtun.\n";
     }
 } else {
-    print "Reset cancelled\n";
+    print "\nReset cancelled\n";
 }

--- a/scripts/vyatta-show-ovpn.pl
+++ b/scripts/vyatta-show-ovpn.pl
@@ -59,12 +59,12 @@ sub output_server_status {
     if (!($lines[0] =~ /^OpenVPN CLIENT LIST$/)) {
         return 0;
     }
-    print <<EOH;
-OpenVPN server status on $intf [$desc] 
-
-Client CN       Remote IP       Tunnel IP       TX byte RX byte Connected Since
---------------- --------------- --------------- ------- ------- ------------------------
-EOH
+    
+    my $format = "%-15s %-15s %-15s %7s %7s %s\n";
+    print "\n";
+    print "OpenVPN server status on $intf [$desc]\n\n"; 
+    printf($format, "Client CN", "Remote IP", "Tunnel IP", "TX byte", "RX byte", "Connected Since");
+    printf($format, "---------", "---------", "---------", "-------", "-------", "---------------");
 
     my @clients = ();
     my %routes = ();
@@ -89,7 +89,7 @@ EOH
         my $rbytes = stat2str($recv);
         my $sbytes = stat2str($sent);
 
-        printf "%-15s %-15s %-15s %7s %7s %s\n",$name, $rip, $tip_str, $sbytes, $rbytes, $since;
+        printf($format,$name, $rip, $tip_str, $sbytes, $rbytes, $since);
     }
     print "\n\n";
 
@@ -189,14 +189,14 @@ sub output_client_status {
     my @lines = @_;
     my $mode = "client";
     my ($desc, $remote, $sent, $recv) = parse_status($intf, $mode, @lines);
-    print <<EOH;
-OpenVPN client status on $intf [$desc]
-
-Server CN       Remote IP       Tunnel IP       TX byte RX byte Connected Since
---------------- --------------- --------------- ------- ------- ------------------------
-EOH
-
-    printf "%-15s %-15s %-15s %7s %7s %s\n","N/A", $remote, "N/A", $sent, $recv, "N/A";
+    
+    my $format = "%-15s %-15s %-15s %7s %7s %s\n";
+    print "\n";
+    print "OpenVPN client status on $intf [$desc]\n\n";
+    printf($format, "Server CN", "Remote IP", "Tunnel IP", "TX byte", "RX byte", "Connected Since");
+    printf($format, "---------", "---------", "---------", "-------", "-------", "---------------");
+    
+    printf($format,"N/A", $remote, "N/A", $sent, $recv, "N/A");
     print "\n\n";
     return 1;
 }
@@ -206,13 +206,14 @@ sub output_sitetosite_status {
     my @lines = @_;
     my $mode = "site-to-site";
     my ($desc, $remote, $sent, $recv, $rsite, $rtunnel) = parse_status($intf, $mode, @lines);
-    print <<EOH;
-OpenVPN client status on $intf [$desc] 
 
-Remote CN       Remote IP       Tunnel IP       TX byte RX byte Connected Since
---------------- --------------- --------------- ------- ------- ------------------------
-EOH
-    printf "%-15s %-15s %-15s %7s %7s %s\n",$rsite, $remote, $rtunnel, $sent, $recv, "N/A";
+    my $format = "%-15s %-15s %-15s %7s %7s %s\n";
+    print "\n";
+    print "OpenVPN client status on $intf [$desc]\n\n";
+    printf($format, "Remote CN", "Remote IP", "Tunnel IP", "TX byte", "RX byte", "Connected Since");
+    printf($format, "---------", "---------", "---------", "-------", "-------", "---------------");
+
+    printf($format, $rsite, $remote, $rtunnel, $sent, $recv, "N/A");
     print "\n\n";
     return 1;
 }


### PR DESCRIPTION
vyatta-openvpn: tidy up output from 'reset openvpn interface vtun0'

Tidy up the output produced by 'reset openvpn interface vtun0' to make
it more readable, following the addition of persistent tunnels.

Bug #7 http://bugzilla.vyos.net/show_bug.cgi?id=7
Bug #313 http://bugzilla.vyos.net/show_bug.cgi?id=313
Bug #318 http://bugzilla.vyos.net/show_bug.cgi?id=318

vyatta-openvpn: tidy up output on "show openvpn <type> status" messages

Tidy up the output of "show openvpn client status" "show openvpn server
status" and "show openvpn site-to-site status".  This stops it rolling
onto the next line and keeps things tidy.

Bug #320 http://bugzilla.vyos.net/show_bug.cgi?id=320
