### PR TITLE
T1259: Fix quotation with --push parameters

### DIFF
--- a/lib/Vyatta/OpenVPN/Config.pm
+++ b/lib/Vyatta/OpenVPN/Config.pm
@@ -842,7 +842,7 @@ sub get_command {
                         return (undef, 'Must specify IP address for "name-server"');
                     }
                 }
-                $cmd .= " --push dhcp-option DNS $nserver";
+                $cmd .= ' --push "dhcp-option DNS $nserver"';
             }
         }
 
@@ -851,12 +851,12 @@ sub get_command {
                 my $s = new NetAddr::IP "$proute";
                 my $n = $s->addr();
                 my $m = $s->mask();
-                $cmd .= " --push route $n $m";
+                $cmd .= ' --push "route $n $m"';
             }
         }
 
         if (defined($self->{_dns_suffix})) {
-            $cmd .= " --push dhcp-option DOMAIN $self->{_dns_suffix}";
+            $cmd .= ' --push "dhcp-option DOMAIN $self->{_dns_suffix}"';
         }
 
         if (defined($self->{_server_mclients})) {


### PR DESCRIPTION
Using some of the server-options on recently rolling release builds fails with:
 `Options error: Unrecognized option or missing or extra parameter(s) in [CMD-LINE]:1: push (2.4.0)`

This seems to be caused by missing quotes around the parameters to --push.

From openvpn man-page:

>        --push option
>               Push a config file option back to the client for remote execution.  Note that option must be enclosed in double quotes ("").

This PR adds double-quotes around the parameters that didn't yet have any.