### PR TITLE
T1259: Fix variable interpolation in quoted --push parameters

### DIFF
--- a/lib/Vyatta/OpenVPN/Config.pm
+++ b/lib/Vyatta/OpenVPN/Config.pm
@@ -842,7 +842,7 @@ sub get_command {
                         return (undef, 'Must specify IP address for "name-server"');
                     }
                 }
-                $cmd .= ' --push "dhcp-option DNS $nserver"';
+                $cmd .= " --push \"dhcp-option DNS $nserver\"";
             }
         }
 
@@ -851,12 +851,12 @@ sub get_command {
                 my $s = new NetAddr::IP "$proute";
                 my $n = $s->addr();
                 my $m = $s->mask();
-                $cmd .= ' --push "route $n $m"';
+                $cmd .= " --push \"route $n $m\"";
             }
         }
 
         if (defined($self->{_dns_suffix})) {
-            $cmd .= ' --push "dhcp-option DOMAIN $self->{_dns_suffix}"';
+            $cmd .= " --push \"dhcp-option DOMAIN $self->{_dns_suffix}\"";
         }
 
         if (defined($self->{_server_mclients})) {


### PR DESCRIPTION
Related to task https://phabricator.vyos.net/T1259

Attempts to correct a partially broken commit a0d7c07f1ff0b5fe7450d3a13c1365b8e3589725
which allowed OpenVPN to start but the variables would be missing because of different quotes

This was discovered in https://phabricator.vyos.net/T1246 which is also related to the quoting issue but in a slightly different way